### PR TITLE
Track last tab url for activity log

### DIFF
--- a/last-tab-activity/README.md
+++ b/last-tab-activity/README.md
@@ -1,0 +1,30 @@
+# Last Tab Activity (MV3)
+
+Enregistre l'URL la plus récente pour chaque onglet afin de la retrouver rapidement même après fermeture.
+
+## Fonctionnalités
+- Dernière URL par onglet (pas de doublons pour un même onglet)
+- Indication ouvert/fermé
+- Ouverture rapide, copie de l'URL, suppression, nettoyage total
+- Recherche par titre/URL
+- UI compacte et moderne
+
+## Installation (Développement)
+1. Ouvrez `chrome://extensions/`
+2. Activez le mode développeur
+3. Cliquez sur « Charger l'extension non empaquetée »
+4. Sélectionnez le dossier `last-tab-activity`
+
+## Structure
+- `manifest.json` — configuration MV3
+- `src/background.js` — écoute des événements d'onglets et enregistrement
+- `src/storage.js` — module de persistance (chrome.storage.local)
+- `popup/` — interface utilisateur (HTML/CSS/JS)
+
+## Notes
+- L'extension n'enregistre qu'une seule entrée par onglet (clé = `tabId`). Quand l'URL change, l'entrée est mise à jour.
+- À la fermeture d'un onglet, l'entrée est marquée comme « Fermé » pour pouvoir reprendre plus tard.
+- Les données sont stockées localement (chrome.storage.local).
+
+## Licence
+MIT

--- a/last-tab-activity/manifest.json
+++ b/last-tab-activity/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Last Tab Activity",
+  "description": "Enregistre l'URL la plus récente par onglet pour la retrouver facilement même après fermeture.",
+  "version": "0.1.0",
+  "permissions": [
+    "storage",
+    "tabs"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Historique d'onglet (dernier état)",
+    "default_popup": "popup/popup.html"
+  },
+  "icons": {
+  }
+}

--- a/last-tab-activity/popup/popup.css
+++ b/last-tab-activity/popup/popup.css
@@ -1,0 +1,119 @@
+:root {
+  --bg: #0f1216;
+  --panel: #161a20;
+  --text: #e8eef6;
+  --muted: #a7b3c3;
+  --accent: #5b9dff;
+  --danger: #ff6b6b;
+  --open: #4caf50;
+  --closed: #ff9800;
+  --border: #2a2f38;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  width: 420px;
+  max-height: 560px;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.title {
+  font-size: 16px;
+  margin: 0;
+}
+
+.actions { display: flex; gap: 8px; }
+
+.search { padding: 8px 12px; border-bottom: 1px solid var(--border); }
+
+#searchInput {
+  width: 100%;
+  padding: 8px 10px;
+  background: #0c0f13;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.favicon {
+  width: 16px; height: 16px;
+}
+
+.meta { overflow: hidden; }
+
+.line1 { display: flex; align-items: center; gap: 8px; }
+
+.line1 .title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status {
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.status.open { color: var(--open); border-color: #28422b; background: #122315; }
+.status.closed { color: var(--closed); border-color: #4a361a; background: #21170c; }
+
+.line2.url {
+  color: var(--muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-actions { display: flex; gap: 6px; }
+
+.btn {
+  background: #10141a;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: #3a3f49; }
+.btn:active { transform: translateY(1px); }
+.btn-open { color: var(--accent); }
+.btn-danger, .btn-delete { color: var(--danger); }
+

--- a/last-tab-activity/popup/popup.html
+++ b/last-tab-activity/popup/popup.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Derniers onglets</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header class="header">
+      <h1 class="title">Derniers onglets</h1>
+      <div class="actions">
+        <button id="clearAllBtn" class="btn btn-danger" title="Tout effacer">Effacer</button>
+      </div>
+    </header>
+    <div class="search">
+      <input id="searchInput" type="search" placeholder="Rechercher par titre ou URL..." autofocus />
+    </div>
+    <main>
+      <ul id="list" class="list" role="list"></ul>
+      <template id="itemTemplate">
+        <li class="item">
+          <img class="favicon" alt="" />
+          <div class="meta">
+            <div class="line1">
+              <span class="title"></span>
+              <span class="status"></span>
+            </div>
+            <div class="line2 url"></div>
+          </div>
+          <div class="item-actions">
+            <button class="btn btn-open" title="Ouvrir">Ouvrir</button>
+            <button class="btn btn-copy" title="Copier l'URL">Copier</button>
+            <button class="btn btn-delete" title="Supprimer">Suppr.</button>
+          </div>
+        </li>
+      </template>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+  </html>
+

--- a/last-tab-activity/popup/popup.js
+++ b/last-tab-activity/popup/popup.js
@@ -1,0 +1,93 @@
+import { getAll, removeTab, clearAll } from "../src/storage.js";
+
+const listEl = document.getElementById("list");
+const searchInput = document.getElementById("searchInput");
+const clearAllBtn = document.getElementById("clearAllBtn");
+
+let allItems = [];
+
+async function load() {
+  const items = await getAll();
+  // Sort by last update desc
+  items.sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt);
+  allItems = items;
+  render(items);
+}
+
+function render(items) {
+  listEl.innerHTML = "";
+  const template = document.getElementById("itemTemplate");
+  for (const item of items) {
+    const node = template.content.cloneNode(true);
+    const li = node.querySelector(".item");
+    const img = node.querySelector(".favicon");
+    const title = node.querySelector(".title");
+    const url = node.querySelector(".url");
+    const status = node.querySelector(".status");
+    const openBtn = node.querySelector(".btn.btn-open");
+    const copyBtn = node.querySelector(".btn.btn-copy");
+    const deleteBtn = node.querySelector(".btn.btn-delete");
+
+    img.src = item.faviconUrl || "";
+    img.width = 16;
+    img.height = 16;
+    img.referrerPolicy = "no-referrer";
+    title.textContent = item.title || "(Sans titre)";
+    url.textContent = item.url;
+    url.title = item.url;
+    status.textContent = item.isClosed ? "Fermé" : "Ouvert";
+    status.className = `status ${item.isClosed ? "closed" : "open"}`;
+
+    openBtn.addEventListener("click", () => openUrl(item.url));
+    copyBtn.addEventListener("click", () => copyToClipboard(item.url));
+    deleteBtn.addEventListener("click", async () => {
+      await removeTab(item.tabId);
+      allItems = allItems.filter((x) => x.tabId !== item.tabId);
+      render(filterByQuery(searchInput.value, allItems));
+    });
+
+    li.dataset.tabId = String(item.tabId);
+    listEl.appendChild(node);
+  }
+}
+
+function filterByQuery(query, items) {
+  const q = (query || "").trim().toLowerCase();
+  if (q.length === 0) return items;
+  return items.filter((it) =>
+    (it.title || "").toLowerCase().includes(q) || (it.url || "").toLowerCase().includes(q)
+  );
+}
+
+function onSearchInput() {
+  const filtered = filterByQuery(searchInput.value, allItems);
+  render(filtered);
+}
+
+async function openUrl(url) {
+  try {
+    await chrome.tabs.create({ url });
+    window.close();
+  } catch (e) {
+    // ignore
+  }
+}
+
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (e) {
+    // ignore
+  }
+}
+
+clearAllBtn.addEventListener("click", async () => {
+  await clearAll();
+  allItems = [];
+  render([]);
+});
+
+searchInput.addEventListener("input", onSearchInput);
+
+load();
+

--- a/last-tab-activity/src/background.js
+++ b/last-tab-activity/src/background.js
@@ -1,0 +1,70 @@
+import { upsertTab, markClosed, updateWindow } from "./storage.js";
+
+/**
+ * Build a record object from a Tab.
+ * @param {chrome.tabs.Tab} tab
+ */
+function buildRecordFromTab(tab) {
+  const url = tab.url || "";
+  return {
+    tabId: tab.id,
+    windowId: tab.windowId,
+    url,
+    title: tab.title || deriveTitleFromUrl(url),
+    faviconUrl: url ? `chrome://favicon/${url}` : "",
+    lastUpdatedAt: Date.now(),
+    isClosed: false
+  };
+}
+
+function deriveTitleFromUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.hostname;
+  } catch (e) {
+    return url || "";
+  }
+}
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (!tabId || !tab) {
+    return;
+  }
+  const urlChanged = typeof changeInfo.url === "string";
+  const isComplete = changeInfo.status === "complete";
+  if (!urlChanged && !isComplete) {
+    return;
+  }
+  const record = buildRecordFromTab(tab);
+  await upsertTab(record);
+});
+
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+  await markClosed(tabId);
+});
+
+chrome.tabs.onAttached.addListener(async (tabId, attachInfo) => {
+  await updateWindow(tabId, attachInfo.newWindowId);
+});
+
+chrome.tabs.onDetached.addListener(async (tabId, detachInfo) => {
+  await updateWindow(tabId, detachInfo.oldWindowId);
+});
+
+// Record current active tabs at startup (service worker cold start)
+async function snapshotOpenTabsOnStartup() {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (tab.id != null) {
+        const record = buildRecordFromTab(tab);
+        await upsertTab(record);
+      }
+    }
+  } catch (e) {
+    // no-op
+  }
+}
+
+snapshotOpenTabsOnStartup();
+

--- a/last-tab-activity/src/storage.js
+++ b/last-tab-activity/src/storage.js
@@ -1,0 +1,136 @@
+const STORAGE_KEY = "tabActivityIndex";
+
+/**
+ * Load the entire tab activity index from chrome.storage.local.
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function loadIndex() {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  const index = result[STORAGE_KEY] || {};
+  if (typeof index !== "object" || Array.isArray(index)) {
+    return {};
+  }
+  return index;
+}
+
+/**
+ * Persist the entire tab activity index to chrome.storage.local.
+ * @param {Record<string, any>} index
+ * @returns {Promise<void>}
+ */
+export async function saveIndex(index) {
+  await chrome.storage.local.set({ [STORAGE_KEY]: index });
+}
+
+/**
+ * Insert or update a tab record.
+ * @param {object} record
+ * @param {number} record.tabId
+ * @param {number} record.windowId
+ * @param {string} record.url
+ * @param {string} record.title
+ * @param {string} record.faviconUrl
+ * @param {number} record.lastUpdatedAt
+ * @param {boolean} record.isClosed
+ */
+export async function upsertTab(record) {
+  const index = await loadIndex();
+  const key = String(record.tabId);
+  const existing = index[key] || {};
+  const merged = {
+    ...existing,
+    ...record
+  };
+  index[key] = sanitizeRecord(merged);
+  await saveIndex(index);
+}
+
+/**
+ * Mark a tab as closed.
+ * @param {number} tabId
+ */
+export async function markClosed(tabId) {
+  const index = await loadIndex();
+  const key = String(tabId);
+  if (!index[key]) {
+    return;
+  }
+  index[key].isClosed = true;
+  index[key].lastUpdatedAt = Date.now();
+  await saveIndex(index);
+}
+
+/**
+ * Remove a tab from the index.
+ * @param {number} tabId
+ */
+export async function removeTab(tabId) {
+  const index = await loadIndex();
+  delete index[String(tabId)];
+  await saveIndex(index);
+}
+
+/**
+ * Clear the entire index.
+ */
+export async function clearAll() {
+  await saveIndex({});
+}
+
+/**
+ * Get all tab records as an array.
+ * @returns {Promise<Array<any>>}
+ */
+export async function getAll() {
+  const index = await loadIndex();
+  return Object.values(index);
+}
+
+/**
+ * Update a tab's window id (e.g., on attach/detach).
+ * @param {number} tabId
+ * @param {number} windowId
+ */
+export async function updateWindow(tabId, windowId) {
+  const index = await loadIndex();
+  const key = String(tabId);
+  const existing = index[key];
+  if (!existing) {
+    return;
+  }
+  index[key] = sanitizeRecord({ ...existing, windowId, lastUpdatedAt: Date.now() });
+  await saveIndex(index);
+}
+
+/**
+ * Ensure record fields are valid and trimmed.
+ * @param {any} record
+ */
+function sanitizeRecord(record) {
+  const safeUrl = typeof record.url === "string" ? record.url : "";
+  const safeTitle = typeof record.title === "string" && record.title.trim().length > 0
+    ? record.title.trim()
+    : deriveTitleFromUrl(safeUrl);
+  const safeFavicon = typeof record.faviconUrl === "string" && record.faviconUrl.trim().length > 0
+    ? record.faviconUrl
+    : (safeUrl ? `chrome://favicon/${safeUrl}` : "");
+  return {
+    tabId: Number(record.tabId),
+    windowId: Number(record.windowId),
+    url: safeUrl,
+    title: safeTitle,
+    faviconUrl: safeFavicon,
+    lastUpdatedAt: typeof record.lastUpdatedAt === "number" ? record.lastUpdatedAt : Date.now(),
+    isClosed: Boolean(record.isClosed)
+  };
+}
+
+function deriveTitleFromUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.hostname;
+  } catch (e) {
+    return url || "";
+  }
+}
+


### PR DESCRIPTION
Implement a Chrome MV3 extension to track and display the last active URL for each tab, allowing users to quickly resume activity.

This addresses the need for a readily accessible, per-tab activity log, especially useful for resuming content like series without consulting browser history.

---
<a href="https://cursor.com/background-agent?bcId=bc-be599e4a-718f-4cf5-9531-fd0d22345e7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be599e4a-718f-4cf5-9531-fd0d22345e7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

